### PR TITLE
Generic column keys, SNR cut, force reference beam

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "numpy>=2.0.0",
+  # numpy==2.0 not required, but not sure which numpy would be lowest
+  "numpy>=1.22.4",
   "astropy",
   "matplotlib",
   "pandas"


### PR DESCRIPTION
Generic column keys, SNR cut, force reference antenna. 

Column keys are a bit clunky, but could be extended easily if more columns are needed. Defaults are still for aegean source lists.

SNR cut defaults to 10sigma, but is specified on the command line as well.

Also added is an option to force a reference beam instead of selecting the beam with the most cross-matches. 