### PR TITLE
Add CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,25 +42,11 @@ pip install git+https://github.com/flint-crew/cross-bones
 pip install cross-bones
 ```
 
-## Usage
+## Usage and documentation
 
 ### Command-line
 
-```bash
-$ cross_bones -h
-# usage: cross_bones [-h] [-o OUTPUT_PREFIX] [--passes PASSES] paths [paths ...]
-
-# Looking at per-beam shifts
-
-# positional arguments:
-#   paths                 The beam wise catalogues to examine
-
-# options:
-#   -h, --help            show this help message and exit
-#   -o OUTPUT_PREFIX, --output-prefix OUTPUT_PREFIX
-#                         The prefix to base outputs onto
-#   --passes PASSES       Number of passes over the data should the iterative method attempt
-```
+Full documentation is hosted on [ReadTheDocs](https://cross-bones.readthedocs.io/en/latest/).
 
 ## Contributing
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,29 @@
+# Command-line Interface
+
+## cross-bones
+
+```{argparse}
+:ref: cross_bones.align_catalogues.get_parser
+:prog: cross_bones
+```
+
+## unWISE
+
+```{argparse}
+:ref: cross_bones.unwise_align_catalogues.get_parser
+:prog: unwise_cross_bones
+```
+
+## Statistics
+
+```{argparse}
+:ref: cross_bones.shift_stats.get_parser
+:prog: shift_stats
+```
+
+## Apply
+
+```{argparse}
+:ref: cross_bones.apply_shifts.get_parser
+:prog: apply_cross_bones
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
     "autoapi.extension",
+    "sphinxarg.ext",
 ]
 
 autoapi_type = "python"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,11 @@
 # cross-bones
 
+## Table of contents
+
 ```{toctree}
-:maxdepth: 2
-:hidden:
+:maxdepth: 1
+
+cli.md
 
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ docs = [
   "sphinx_autodoc_typehints",
   "furo>=2023.08.17",
   "sphinx-autoapi",
+  "sphinx-argparse",
 ]
 
 [project.urls]


### PR DESCRIPTION
Uses `sphinx-argparse` to automagically generate CLI docs.

Closes #19