### PR TITLE
Rerturn NaN when too few sources

### DIFF
--- a/cross_bones/plotting.py
+++ b/cross_bones/plotting.py
@@ -137,7 +137,7 @@ def plot_offset_grid_space(
 
 
 def plot_offsets_in_field(
-    offset_results: list[OffsetGridSpace],
+    offset_results: list[OffsetGridSpace | None],
     windows: list[tuple[float, float, float, float, float]],
     fname: str | Path,
 ) -> None:
@@ -160,6 +160,9 @@ def plot_offsets_in_field(
     fig, axes = plt.subplots(num_columns, num_rows, figsize=(10, 10))
 
     for offset_result, ax, window in zip(offset_results, axes.flatten()[::-1], windows):
+        if offset_result is None:
+            continue
+
         minimum_point = find_minimum_offset_space(offset_space=offset_result)
 
         min_dec = minimum_point[1]


### PR DESCRIPTION
Returns NaN as a an offset when too few sources in a catalogue after filtering. The current default is 1 source, but can be user-specified on the command line. The output grid plot will just have empty squares.

The only point of contention is whether the fill value should be NaN ("nan" in output csv) or 0. 0 is a potential real value so I'm not a fan of using that.  